### PR TITLE
User Interface Changes & Faster Converstion

### DIFF
--- a/PhotoModeApp/App.xaml.cs
+++ b/PhotoModeApp/App.xaml.cs
@@ -116,7 +116,9 @@ namespace PhotoModeApp
         /// </summary>
         private void OnDispatcherUnhandledException(object sender, DispatcherUnhandledExceptionEventArgs e)
         {
-            // For more info see https://docs.microsoft.com/en-us/dotnet/api/system.windows.application.dispatcherunhandledexception?view=windowsdesktop-6.0
+            MessageBox.Show(e.Exception.ToString() + "\n\nThe application has been stopped to prevent further issues. The app will now close.", "An error has occured.", MessageBoxButton.OK, MessageBoxImage.Error);
+            e.Handled = true;
+            Application.Current.Shutdown();
         }
     }
 }

--- a/PhotoModeApp/Helpers/RagePhoto.cs
+++ b/PhotoModeApp/Helpers/RagePhoto.cs
@@ -1,0 +1,62 @@
+﻿using System;
+using System.IO;
+using System.Runtime.InteropServices;
+
+namespace PhotoModeApp.Helpers
+{
+    internal static class RagePhoto
+    {
+        [DllImport("libragephoto.dll")]
+        private static extern IntPtr ragephoto_open();
+
+        [DllImport("libragephoto.dll")]
+        private static extern void ragephoto_close(IntPtr instance);
+
+        [DllImport("libragephoto.dll", CharSet = CharSet.Ansi)]
+        private static extern int ragephoto_loadfile(IntPtr instance, [MarshalAs(UnmanagedType.LPStr)] string filename);
+
+        [DllImport("libragephoto.dll")]
+        private static extern byte ragephoto_error(IntPtr instance);
+
+        [DllImport("libragephoto.dll")]
+        private static extern int ragephoto_getphotosize(IntPtr instance);
+
+        [DllImport("libragephoto.dll")]
+        private static extern IntPtr ragephoto_getphotojpeg(IntPtr instance);
+
+
+        public static void Convert(string input)
+        {
+            IntPtr instance = ragephoto_open();
+
+            int result = ragephoto_loadfile(instance, input);
+
+            if (result != 1)
+            {
+                if (ragephoto_error(instance) == 0)
+                {
+                    throw new FileNotFoundException($"File {input} could not be found.");
+                }
+
+                else if (ragephoto_getphotosize(instance) <= 0)
+                {
+                    throw new InvalidDataException($"Unable to load photo {input}");
+                }
+            }
+
+            byte[] bytes = new byte[ragephoto_getphotosize(instance)];
+
+            IntPtr ptr = ragephoto_getphotojpeg(instance);
+
+            Marshal.Copy(ptr, bytes, 0, ragephoto_getphotosize(instance));
+
+            FileStream fileStream = File.Create(input + ".jpg");
+
+            fileStream.Write(bytes, 0, bytes.Length);
+
+            fileStream.Close();
+
+            ragephoto_close(instance);
+        }
+    }
+}

--- a/PhotoModeApp/Helpers/Win32Files.cs
+++ b/PhotoModeApp/Helpers/Win32Files.cs
@@ -38,7 +38,7 @@ namespace PhotoModeApp.Helpers
 
         public static int GetFileCount(string dir, bool includeSubdirectories = false)
         {
-            string searchPattern = Path.Combine(dir, "*");
+            string searchPattern = Path.Combine(dir, "PRDR3*.");
 
             var findFileData = new WIN32_FIND_DATA();
             IntPtr hFindFile = FindFirstFile(searchPattern, ref findFileData);

--- a/PhotoModeApp/PhotoModeApp.csproj
+++ b/PhotoModeApp/PhotoModeApp.csproj
@@ -29,7 +29,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Toolkit.Uwp.Notifications" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Toolkit.Uwp.Notifications" Version="7.1.2" />
     <PackageReference Include="Ookii.Dialogs.Wpf" Version="5.0.1" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.1" />
     <PackageReference Include="Microsoft.Toolkit.Mvvm" Version="7.1.2" />

--- a/PhotoModeApp/PhotoModeApp.csproj
+++ b/PhotoModeApp/PhotoModeApp.csproj
@@ -9,7 +9,7 @@
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationIcon>appicon.ico</ApplicationIcon>
     <AssemblyName>Photo Mode Converter</AssemblyName>
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <AllowUnsafeBlocks>False</AllowUnsafeBlocks>
     <FileVersion>1.1.0.0</FileVersion>
     <AssemblyVersion>1.1.0.0</AssemblyVersion>
   </PropertyGroup>

--- a/PhotoModeApp/PhotoModeApp.csproj
+++ b/PhotoModeApp/PhotoModeApp.csproj
@@ -9,6 +9,9 @@
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationIcon>appicon.ico</ApplicationIcon>
     <AssemblyName>Photo Mode Converter</AssemblyName>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <FileVersion>1.1.0.0</FileVersion>
+    <AssemblyVersion>1.1.0.0</AssemblyVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/PhotoModeApp/ViewModels/SettingsViewModel.cs
+++ b/PhotoModeApp/ViewModels/SettingsViewModel.cs
@@ -8,60 +8,14 @@ namespace PhotoModeApp.ViewModels
 {
     public partial class SettingsViewModel : ObservableObject, INavigationAware
     {
-        private bool _isInitialized = false;
-
-        [ObservableProperty]
-        private string _appVersion = String.Empty;
-
-        [ObservableProperty]
-        private Wpf.Ui.Appearance.ThemeType _currentTheme = Wpf.Ui.Appearance.ThemeType.Unknown;
-
         public void OnNavigatedTo()
         {
-            if (!_isInitialized)
-                InitializeViewModel();
+
         }
 
         public void OnNavigatedFrom()
         {
-        }
 
-        private void InitializeViewModel()
-        {
-            CurrentTheme = Wpf.Ui.Appearance.Theme.GetAppTheme();
-            AppVersion = $"Photo Mode Application - {GetAssemblyVersion()}";
-
-            _isInitialized = true;
-        }
-
-        private string GetAssemblyVersion()
-        {
-            return System.Reflection.Assembly.GetExecutingAssembly().GetName().Version?.ToString() ?? String.Empty;
-        }
-
-        [ICommand]
-        private void OnChangeTheme(string parameter)
-        {
-            switch (parameter)
-            {
-                case "theme_light":
-                    if (CurrentTheme == Wpf.Ui.Appearance.ThemeType.Light)
-                        break;
-
-                    Wpf.Ui.Appearance.Theme.Apply(Wpf.Ui.Appearance.ThemeType.Light);
-                    CurrentTheme = Wpf.Ui.Appearance.ThemeType.Light;
-
-                    break;
-
-                default:
-                    if (CurrentTheme == Wpf.Ui.Appearance.ThemeType.Dark)
-                        break;
-
-                    Wpf.Ui.Appearance.Theme.Apply(Wpf.Ui.Appearance.ThemeType.Dark);
-                    CurrentTheme = Wpf.Ui.Appearance.ThemeType.Dark;
-
-                    break;
-            }
         }
     }
 }

--- a/PhotoModeApp/Views/Container.xaml
+++ b/PhotoModeApp/Views/Container.xaml
@@ -9,10 +9,11 @@
     xmlns:ui="http://schemas.lepo.co/wpfui/2022/xaml"
     Title="{Binding ViewModel.ApplicationTitle, Mode=OneWay}"
     SizeToContent="WidthAndHeight" ResizeMode="NoResize"
-    Width="400"
-    Height="400"
-    MaxWidth="400"
-    MaxHeight="300"
+    Width="525"
+    Height="200"
+    MaxWidth="525"
+    MinWidth="525"
+    MaxHeight="200"
     d:DataContext="{d:DesignInstance local:Container,
                                      IsDesignTimeCreatable=True}"
     ExtendsContentIntoTitleBar="True"
@@ -20,7 +21,7 @@
     WindowCornerPreference="Round"
     WindowStartupLocation="CenterScreen"
     mc:Ignorable="d">
-    
+
     <Grid>
         <Grid.ColumnDefinitions>
             <ColumnDefinition Width="Auto" />
@@ -62,14 +63,14 @@
                         <RowDefinition Height="Auto" />
                         <RowDefinition Height="*" />
                     </Grid.RowDefinitions>
-                    <Frame x:Name="RootFrame" Grid.Row="1" />
+                    <Frame x:Name="RootFrame" Margin="0,53,0,0" Grid.Row="1" />
                     <ui:Breadcrumb
                         Grid.Row="0"
-                        Margin="56,32"
+                        Margin="24,10,0,0"
                         HorizontalAlignment="Left"
                         VerticalAlignment="Top"
                         FontSize="28"
-                        Navigation="{Binding ElementName=RootNavigation, Mode=OneWay}" />
+                        Navigation="{Binding ElementName=RootNavigation, Mode=OneWay}" Grid.RowSpan="2" />
                 </Grid>
             </Border>
         </Grid>

--- a/PhotoModeApp/Views/Pages/DashboardPage.xaml
+++ b/PhotoModeApp/Views/Pages/DashboardPage.xaml
@@ -14,18 +14,13 @@
     Foreground="{DynamicResource TextFillColorPrimaryBrush}"
     mc:Ignorable="d">
 
-    <Grid Margin="56,0,56,0" VerticalAlignment="Top" Height="155">
+    <Grid VerticalAlignment="Top" Height="448" Margin="0,2,0,0">
         <Grid.ColumnDefinitions>
-            <ColumnDefinition Width="Auto" />
-            <ColumnDefinition Width="Auto" />
         </Grid.ColumnDefinitions>
 
-        <ui:CardAction Name="PathAction" Content="Set Path" HorizontalAlignment="Left" Margin="0,10,0,0" VerticalAlignment="Top" Grid.ColumnSpan="2" Width="295" Height="53" Click="PathAction_ClickAsync"/>
-        <ui:Button
-            Name="ConvertButton"
-            Content="Convert"
-            Icon="Fluent24" Margin="0,68,0,0" Height="30" Width="204" RenderTransformOrigin="-0.032,0.484" VerticalAlignment="Top" Click="ConvertButton_Click" Grid.RowSpan="1" IsDefault="True" >
-        </ui:Button>
-        <ui:TextBox Name="ProgressText" Visibility="Hidden" HorizontalAlignment="Left" Margin="0,110,0,0" TextWrapping="Wrap" Text="TextBox" VerticalAlignment="Top" Width="204"/>
+        <ui:CardAction Name="PathAction" Content="Set Path" HorizontalAlignment="Left" VerticalAlignment="Top" Width="295" Height="53" Click="PathAction_ClickAsync" Margin="25,55,0,0"/>
+        <ui:Button Name="ConvertButton" Content="Convert" Icon="Fluent24" Margin="339,55,0,0" Height="53" VerticalAlignment="Top" Click="ConvertButton_Click" IsDefault="True" HorizontalAlignment="Left" Width="111"/>
+        <TextBlock Text="Please select a folder where your &quot;PRDR&quot; files are, then click &quot;Convert&quot; to get&#xD;&#xA;the raw JPEG image files. The raw JPEG image files are stored in the &#xD;&#xA;ConvertedImages folder, inside the folder that you had selected." HorizontalAlignment="Left" Margin="25,0,0,0" VerticalAlignment="Top" Background="{x:Null}"/>
+        <TextBlock x:Name="StatusLabel" Text="" HorizontalAlignment="Left" Margin="25,113,0,0" VerticalAlignment="Top" Width="415" Height="65"/>
     </Grid>
 </ui:UiPage>

--- a/PhotoModeApp/Views/Pages/SettingsPage.xaml
+++ b/PhotoModeApp/Views/Pages/SettingsPage.xaml
@@ -14,31 +14,21 @@
     d:DesignWidth="800"
     Foreground="{DynamicResource TextFillColorPrimaryBrush}"
     mc:Ignorable="d">
-    <ui:UiPage.Resources>
-        <helpers:EnumToBooleanConverter x:Key="EnumToBooleanConverter" />
-    </ui:UiPage.Resources>
 
-    <StackPanel Margin="56,0">
+    <Grid VerticalAlignment="Top" Height="448" Margin="0,2,0,0">
+        <TextBlock Text="Theme" Width="49" Margin="25,32,0,0" HorizontalAlignment="Left" VerticalAlignment="Top" />
         <TextBlock
             FontSize="20"
             FontWeight="Medium"
-            Text="Personalization" />
-        <Grid VerticalAlignment="Center" HorizontalAlignment="Left" Margin="0,5,0,4"/>
-        <TextBlock Text="Theme" />
-        <RadioButton
-            Margin="0,12,0,0"
-            Command="{Binding ViewModel.OnChangeThemeCommand, Mode=OneWay}"
-            CommandParameter="theme_light"
-            Content="Light"
-            GroupName="themeSelect"
-            IsChecked="{Binding ViewModel.CurrentTheme, Converter={StaticResource EnumToBooleanConverter}, ConverterParameter=Light, Mode=OneWay}" />
-        <RadioButton
-            Margin="0,8,0,0"
-            Command="{Binding ViewModel.OnChangeThemeCommand, Mode=OneWay}"
-            CommandParameter="theme_dark"
-            Content="Dark"
-            GroupName="themeSelect"
-            IsChecked="{Binding ViewModel.CurrentTheme, Converter={StaticResource EnumToBooleanConverter}, ConverterParameter=Dark, Mode=OneWay}" />
-        <TextBlock TextWrapping="Wrap" Text="Developed by pointerboy" Margin="0,7,0,0"/>
-    </StackPanel>
+            Text="Personalization" Margin="25,0,0,0" HorizontalAlignment="Left" VerticalAlignment="Top" />
+        <TextBlock TextWrapping="Wrap" Text="© 2022 pointerboy." Margin="211,48,0,0" Width="138" HorizontalAlignment="Left" VerticalAlignment="Top" TextAlignment="Center"/>
+        <ComboBox x:Name="ThemeSelectionDropDown" HorizontalAlignment="Left" Margin="25,53,0,0" VerticalAlignment="Top" Width="120" IsEditable="True"/>
+        <ui:Hyperlink Content="Source Code" HorizontalAlignment="Left" Margin="211,69,0,0" VerticalAlignment="Top" NavigateUri="https://github.com/pointerboy/PhotoModeApp" Width="138" Icon="Empty"/>
+        <ui:Hyperlink Content="Mod Page" HorizontalAlignment="Left" Margin="211,107,0,0" VerticalAlignment="Top" NavigateUri="https://www.rdr2mods.com/downloads/rdr2/tools/325-photo-mode-converter/" Width="138" Icon="Empty"/>
+        <TextBlock
+            FontSize="20"
+            FontWeight="Medium"
+            Text="About" Margin="252,0,0,0" HorizontalAlignment="Left" VerticalAlignment="Top" />
+        <TextBlock x:Name="VersionText" TextWrapping="Wrap" Text="Version: " Margin="211,27,0,0" Width="138" HorizontalAlignment="Left" VerticalAlignment="Top" TextAlignment="Center"/>
+    </Grid>
 </ui:UiPage>

--- a/PhotoModeApp/Views/Pages/SettingsPage.xaml.cs
+++ b/PhotoModeApp/Views/Pages/SettingsPage.xaml.cs
@@ -1,4 +1,8 @@
-﻿using Wpf.Ui.Common.Interfaces;
+﻿using System.Collections.Generic;
+using System.Reflection;
+using System.Windows;
+using System.Windows.Controls;
+using Wpf.Ui.Common.Interfaces;
 
 namespace PhotoModeApp.Views.Pages
 {
@@ -17,6 +21,42 @@ namespace PhotoModeApp.Views.Pages
             ViewModel = viewModel;
 
             InitializeComponent();
+
+            this.Loaded += SettingsPage_Loaded;
+        }
+
+        private void SettingsPage_Loaded(object sender, RoutedEventArgs e)
+        {
+            VersionText.Text += Assembly.GetExecutingAssembly().GetName().Version;
+
+            ThemeSelectionDropDown.ItemsSource = new List<string> { "Light", "Dark" };
+
+            switch (Wpf.Ui.Appearance.Theme.GetAppTheme())
+            {
+                case Wpf.Ui.Appearance.ThemeType.Light:
+                    ThemeSelectionDropDown.Text = "Light";
+                    break;
+                case Wpf.Ui.Appearance.ThemeType.Dark:
+                    ThemeSelectionDropDown.Text = "Dark";
+                    break;
+            }
+
+            ThemeSelectionDropDown.IsEditable = false;
+
+            ThemeSelectionDropDown.SelectionChanged += ThemeSelectionDropDown_DataContextChanged;
+        }
+
+        private void ThemeSelectionDropDown_DataContextChanged(object sender, SelectionChangedEventArgs e)
+        {
+            switch (e.AddedItems[0].ToString())
+            {
+                case "Light":
+                    Wpf.Ui.Appearance.Theme.Apply(Wpf.Ui.Appearance.ThemeType.Light);
+                    break;
+                case "Dark":
+                    Wpf.Ui.Appearance.Theme.Apply(Wpf.Ui.Appearance.ThemeType.Dark);
+                    break;
+            }
         }
     }
 }

--- a/PhotoModeApp/app.manifest
+++ b/PhotoModeApp/app.manifest
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
-  <assemblyIdentity version="1.0.0.0" name="PhotoModeApp.app"/>
+  <assemblyIdentity version="1.1.0.0" name="PhotoModeApp.app"/>
 	<SquirrelAwareVersion xmlns="urn:schema-squirrel-com:asm.v1">1</SquirrelAwareVersion>
   <trustInfo xmlns="urn:schemas-microsoft-com:asm.v2">
     <security>


### PR DESCRIPTION
Changed the user interface layout to make it fit the design style of Windows 11 more. Added info on how to use the app. Added links to source code and mod page in settings. 

Improved conversion times by directly using the [libragephoto](https://github.com/Syping/libragephoto) library instead of using ragephoto-extract.exe. This also fixed the app not being able to handle large amounts of files. 

Fixed issue where an error occurs when converting after selecting the folder inside `Rockstar Games\Red Dead Redemption 2\Profiles`.

![image](https://user-images.githubusercontent.com/80211714/188283480-85dd00d8-b4ea-4fbe-9358-23576cf12d24.png)
![image](https://user-images.githubusercontent.com/80211714/188283487-fdc93cc5-269a-4246-a5bd-29f282219146.png)
